### PR TITLE
해인 모바일 css + 메뉴의 href 수정

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -128,6 +128,84 @@
         padding-top: 20px;
       }
 
+      @media screen and (max-width: 900px) {     
+            .sitetop {
+                width: 100%;
+                height: 160px;
+                background-image: url("https://miro.medium.com/max/1400/1*T4H2-9ToU2Eg5yns8YQhIA.jpeg");
+                background-size: cover;
+                background-position: center;
+            }
+            
+            .sitetitle {
+                margin: 0px;
+                padding: 50px 0px;
+                text-align: center;
+                font-family: "Arial Black", sans-serif;
+                font-size: 40px;
+                font-weight: bold;
+                color: #ffffff;
+                text-shadow: 2px 2px 0px #333333;
+            }
+
+            /* Add a black background color to the top navigation */
+            .topnav {
+                width: 100%;
+                margin: auto;
+                background-color: #333;
+                overflow: hidden;
+            }
+
+            /* Style the links inside the navigation bar */
+            .topnav a {
+                float: left;
+                color: #f2f2f2;
+                text-align: center;
+                padding: 10px 16px;
+                text-decoration: none;
+                font-size: 12px;
+            }
+
+            /* Change the color of links on hover */
+            .topnav a:hover {
+                background-color: #ddd;
+                color: black;
+            }
+
+            /* Add a color to the active/current link */
+            .topnav a.active {
+                background-color: darkgoldenrod;
+                color: white;
+            }
+
+            .wrap {
+                width: 100%;
+            }
+           
+            /* index.html만의 부분 s */
+            .card-deck {
+                width: 100%;
+                padding-bottom: 5px;
+
+            }
+
+            .card {
+                min-width: 250px;
+            }
+            /* index.html만의 부분 e */
+            
+
+            .footer {
+                width: 100%;
+                bottom: 10px;
+                height: 3rem; /* 푸터 높이 */
+                background-color: darkgoldenrod;
+                text-align: center;
+                color: white;
+            }
+        }
+        /* !!여기는 모바일 버전 css 끝!! */
+
     </style>
 </head>
 <body>
@@ -136,8 +214,8 @@
             <h1 class="sitetitle">우리의 여행</h1>
         </div>
         <div class="topnav">
-            <a class="active" href="index.html">우리의 여행일기</a>
-            <a href="write.html">일기 쓰기</a>
+            <a class="active" href="/">우리의 여행일기</a>
+            <a href="/menu1">일기 쓰기</a>
             <a href="#mypost">내 일기 모아보기</a>
             <a href="#about">about</a>
           </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -107,7 +107,6 @@
         }
 
         .footer {
-            position: absolute;
             bottom: 10px;
             height: 3rem; /* 푸터 높이 */
             background-color: darkgoldenrod;

--- a/templates/write.html
+++ b/templates/write.html
@@ -126,6 +126,7 @@
             margin-top: 15px;
             margin-bottom: 20px;
         }
+
         /* 포스팅 관련 css 끝 */
 
         .footer {
@@ -136,18 +137,16 @@
             text-align: center;
             color: white;
         }
-        /* write.html만의 부분 e */
 
-        
         /* !!여기는 모바일 버전 css !! */
-        @media screen and (max-width: 780px) {
-            /* 아직 write.html에만 작성했고 전체 html에 통일할 계획 s */         
+        @media screen and (max-width: 900px) {   
             .sitetop {
                 width: 100%;
                 height: 160px;
                 background-image: url("https://miro.medium.com/max/1400/1*T4H2-9ToU2Eg5yns8YQhIA.jpeg");
                 background-size: cover;
                 background-position: center;
+                margin-top: 0;
             }
             
             .sitetitle {
@@ -194,7 +193,6 @@
             .wrap {
                 width: 100%;
             }
-            /* 아직 write.html에만 작성했고 전체 html에 통일할 계획 e */
 
             /* write.html만의 부분 s */
             .form-post {
@@ -225,7 +223,6 @@
             // 이것은 파일업로드 할때 파일명을 보이게 해주는 코드
             bsCustomFileInput.init()
         })
-
     </script>
 
 </head>
@@ -235,15 +232,15 @@
     <div class="sitetop">
         <h1 class="sitetitle">우리의 여행</h1>
     </div>
-    <div class="topnav" id="navbar">
-        <a href="index.html">우리의 여행일기</a>
-        <a class="active" href="write.html">일기 쓰기</a>
+    <div class="topnav">
+        <a href="/">우리의 여행일기</a>
+        <a class="active" href="/menu1">일기 쓰기</a>
         <a href="#mypost">내 일기 모아보기</a>
         <a href="#about">about</a>
     </div>
 </header>
 
-<div class="wrap" id="sitemiddle">
+<div class="wrap">
 
     <!--본문 부분: 기록 작성-->
     <div class="form-post" id="post-box">
@@ -265,28 +262,6 @@
                 <input class="form-control" id="post-title" placeholder="일기 제목">
             </div>
 
-<<<<<<< HEAD
-                <!--날짜-->
-                <div class="form-group">
-                    <input type="date" class="form-control" id="post-date" name="trip-start"
-                        placeholder="날짜 선택">
-                </div>
-
-                <!--날씨 중에 쓸 이모티콘을 선택해야 함-->
-                <div class="form-group">
-                    <select class="custom-select" id="post-weather">
-                        <option selected>날씨 선택</option>
-                        <option value="1">☀️</option>
-                        <option value="2">⛅</option>
-                        <option value="3">☁️</option>
-                        <option value="4">⛈️</option>
-                        <option value="5">☔</option>
-                        <option value="6">🌧️</option>
-                        <option value="7">🌩️</option>
-                        <option value="8">❄️</option>
-                    </select>
-                </div>
-=======
             <!--날짜-->
             <div class="form-group">
                 <input type="date" class="form-control" id="post-date" name="trip-start"
@@ -306,7 +281,6 @@
                 <button type="button" class="btn">⚡</button>
                 <button type="button" class="btn">☃️️</button>
             </div>
->>>>>>> 207e6a5501fbe0d0d2d1b28fff7f8783a8bd0466
 
 
             <!--사진첨부-->
@@ -315,16 +289,6 @@
                 <label class="custom-file-label" for="file">사진 선택</label>
             </div>
 
-<<<<<<< HEAD
-                <!--내용작성-->
-                <div class="form-group-comment">
-                    <label for="post-comment">간단 코멘트</label>
-                    <textarea class="form-control" id="post-comment" rows="2"></textarea>
-                </div>
-
-                <button class="btn btn-primary" onclick="postArticle()" type="button">기록 저장</button>
-            </div>
-=======
             <!--내용작성-->
             <div class="form-group-comment">
                 <label for="post-comment">일기 내용</label>
@@ -332,7 +296,6 @@
             </div>
 
             <button class="btn btn-primary" onclick="postArticle()" type="button">일기 저장</button>
->>>>>>> 207e6a5501fbe0d0d2d1b28fff7f8783a8bd0466
         </div>
     </div>
     <div class="card-columns" id="cards-box">

--- a/templates/write.html
+++ b/templates/write.html
@@ -122,15 +122,39 @@
         }
         /* 포스팅 관련 css 끝 */
 
+        .footer {
+            bottom: 10px;
+            height: 3rem; /* 푸터 높이 */
+            background-color: darkgoldenrod;
+            width: 900px;
+            text-align: center;
+            color: white;
+        }
+        /* write.html만의 부분 e */
 
-         /* write.html만의 부분 e */
-         @media screen and (max-width: 780px) {
+        
+        /* !!여기는 모바일 버전 css !! */
+        @media screen and (max-width: 780px) {
             /* 아직 write.html에만 작성했고 전체 html에 통일할 계획 s */         
             .sitetop {
                 width: 100%;
-                height: 200px;
+                height: 160px;
+                background-image: url("https://miro.medium.com/max/1400/1*T4H2-9ToU2Eg5yns8YQhIA.jpeg");
+                background-size: cover;
+                background-position: center;
             }
             
+            .sitetitle {
+                margin: 0px;
+                padding: 50px 0px;
+                text-align: center;
+                font-family: "Arial Black", sans-serif;
+                font-size: 40px;
+                font-weight: bold;
+                color: #ffffff;
+                text-shadow: 2px 2px 0px #333333;
+            }
+
             /* Add a black background color to the top navigation */
             .topnav {
                 width: 100%;
@@ -146,7 +170,7 @@
                 text-align: center;
                 padding: 10px 16px;
                 text-decoration: none;
-                font-size: 15px;
+                font-size: 12px;
             }
 
             /* Change the color of links on hover */
@@ -157,16 +181,8 @@
 
             /* Add a color to the active/current link */
             .topnav a.active {
-                background-color: #04aa6d;
+                background-color: darkgoldenrod;
                 color: white;
-            }
-
-            .fixed {
-                position: -webkit-sticky;
-                position: sticky;
-                top: 0;
-                z-index: 100;
-                width: 100%;
             }
 
             .wrap {
@@ -179,20 +195,23 @@
                 width: 80%;
                 padding: 30px 25px 25px 20px;
                 margin: auto;
+                margin-top: 25px;
+                margin-bottom: 40px;
+                
             }
             /* write.html만의 부분 e */
-            /* !!여기는 모바일 버전 css 끝!! */
-        }
+            
 
-
-        .footer {
-            bottom: 10px;
-            height: 3rem; /* 푸터 높이 */
-            background-color: darkgoldenrod;
-            width: 900px;
-            text-align: center;
-            color: white;
+            .footer {
+                width: 100%;
+                bottom: 10px;
+                height: 3rem; /* 푸터 높이 */
+                background-color: darkgoldenrod;
+                text-align: center;
+                color: white;
+            }
         }
+        /* !!여기는 모바일 버전 css 끝!! */
     </style>
 
     <script>
@@ -201,13 +220,6 @@
             bsCustomFileInput.init()
         })
 
-        $(window).scroll(function(){
-            var topnav_sticky = $('.topnav'),
-                scroll = $(window).scrollTop();
-
-            if (scroll >= 100) sticky.addClass('fixed');
-            else topnav_sticky.removeClass('fixed');
-        });
     </script>
 
 </head>
@@ -217,7 +229,7 @@
     <div class="sitetop">
         <h1 class="sitetitle">우리의 여행</h1>
     </div>
-    <div class="topnav">
+    <div class="topnav" id="navbar">
         <a href="index.html">우리의 여행일기</a>
         <a class="active" href="write.html">일기 쓰기</a>
         <a href="#mypost">내 일기 모아보기</a>
@@ -225,7 +237,7 @@
     </div>
 </header>
 
-<div class="wrap">
+<div class="wrap" id="sitemiddle">
 
     <!--본문 부분: 기록 작성-->
     <div class="form-post" id="post-box">

--- a/templates/write.html
+++ b/templates/write.html
@@ -90,7 +90,7 @@
             margin: auto;
         }
 
-        /* 포스팅 관련 css 시작 */
+        /* write.html만의 부분 s */
      .form-post {
             width: 500px;
             margin: 20px auto;
@@ -104,7 +104,67 @@
             margin-top: 15px;
             margin-bottom: 20px;
         }
-        /* 포스팅 관련 css 끝 */
+        /* write.html만의 부분 e */
+
+        @media screen and (max-width: 780px) {
+            /* 아직 write.html에만 작성했고 전체 html에 통일할 계획 s */         
+            .sitetop {
+                width: 100%;
+                height: 200px;
+            }
+            
+            /* Add a black background color to the top navigation */
+            .topnav {
+                width: 100%;
+                margin: auto;
+                background-color: #333;
+                overflow: hidden;
+            }
+
+            /* Style the links inside the navigation bar */
+            .topnav a {
+                float: left;
+                color: #f2f2f2;
+                text-align: center;
+                padding: 10px 16px;
+                text-decoration: none;
+                font-size: 15px;
+            }
+
+            /* Change the color of links on hover */
+            .topnav a:hover {
+                background-color: #ddd;
+                color: black;
+            }
+
+            /* Add a color to the active/current link */
+            .topnav a.active {
+                background-color: #04aa6d;
+                color: white;
+            }
+
+            .fixed {
+                position: -webkit-sticky;
+                position: sticky;
+                top: 0;
+                z-index: 100;
+                width: 100%;
+            }
+
+            .wrap {
+                width: 100%;
+            }
+            /* 아직 write.html에만 작성했고 전체 html에 통일할 계획 e */
+
+            /* write.html만의 부분 s */
+            .form-post {
+                width: 80%;
+                padding: 30px 25px 25px 20px;
+                margin: auto;
+            }
+            /* write.html만의 부분 e */
+            /* !!여기는 모바일 버전 css 끝!! */
+        }
 
     </style>
 
@@ -113,12 +173,20 @@
             // 이것은 파일업로드 할때 파일명을 보이게 해주는 코드
             bsCustomFileInput.init()
         })
+
+        $(window).scroll(function(){
+            var topnav_sticky = $('.topnav'),
+                scroll = $(window).scrollTop();
+
+            if (scroll >= 100) sticky.addClass('fixed');
+            else topnav_sticky.removeClass('fixed');
+        });
     </script>
 
   </head>
 
   <body>
-    <header class="wrap">
+    <header class="wrap" id="myheader">
         <div class="sitetop">
             우리의 여행
         </div>
@@ -135,58 +203,55 @@
     <div class="wrap">
 
         <!--본문 부분: 기록 작성-->
-    <div class="form-post" id="post-box">
-        <div>
-            <div class="form-group">
-                <input class="form-control" id="post-writer" placeholder="작성자">
-            </div>
-            <div class="form-group">
-                <input class="form-control" id="post-place" placeholder="장소">
-            </div>
-            <div class="form-group">
-                <input class="form-control" id="post-title" placeholder="제목">
-            </div>
+        <div class="form-post" id="post-box">
+            <div>
+                <div class="form-group">
+                    <input class="form-control" id="post-writer" placeholder="작성자">
+                </div>
+                <div class="form-group">
+                    <input class="form-control" id="post-place" placeholder="장소">
+                </div>
+                <div class="form-group">
+                    <input class="form-control" id="post-title" placeholder="제목">
+                </div>
 
-            <!--날짜-->
-            <div class="form-group">
-                <input type="date" class="form-control" id="post-date" name="trip-start"
-                       placeholder="날짜 선택">
-            </div>
+                <!--날짜-->
+                <div class="form-group">
+                    <input type="date" class="form-control" id="post-date" name="trip-start"
+                        placeholder="날짜 선택">
+                </div>
 
-            <!--날씨 중에 쓸 이모티콘을 선택해야 함-->
-            <div class="form-group">
-                <select class="custom-select" id="post-weather">
-                    <option selected>날씨 선택</option>
-                    <option value="1">☀️</option>
-                    <option value="2">⛅</option>
-                    <option value="3">☁️</option>
-                    <option value="4">⛈️</option>
-                    <option value="5">☔</option>
-                    <option value="6">🌧️</option>
-                    <option value="7">🌩️</option>
-                    <option value="8">❄️</option>
-                </select>
-            </div>
+                <!--날씨 중에 쓸 이모티콘을 선택해야 함-->
+                <div class="form-group">
+                    <select class="custom-select" id="post-weather">
+                        <option selected>날씨 선택</option>
+                        <option value="1">☀️</option>
+                        <option value="2">⛅</option>
+                        <option value="3">☁️</option>
+                        <option value="4">⛈️</option>
+                        <option value="5">☔</option>
+                        <option value="6">🌧️</option>
+                        <option value="7">🌩️</option>
+                        <option value="8">❄️</option>
+                    </select>
+                </div>
 
-            <!--사진첨부-->
-            <div class="custom-file">
-                    <input type="file" class="custom-file-input" id="file">
-                    <label class="custom-file-label" for="file">사진 선택</label>
-            </div>
+                <!--사진첨부-->
+                <div class="custom-file">
+                        <input type="file" class="custom-file-input" id="file">
+                        <label class="custom-file-label" for="file">사진 선택</label>
+                </div>
 
-            <!--내용작성-->
-            <div class="form-group-comment">
-                <label for="post-comment">간단 코멘트</label>
-                <textarea class="form-control" id="post-comment" rows="2"></textarea>
-            </div>
+                <!--내용작성-->
+                <div class="form-group-comment">
+                    <label for="post-comment">간단 코멘트</label>
+                    <textarea class="form-control" id="post-comment" rows="2"></textarea>
+                </div>
 
-            <button class="btn btn-primary" onclick="postArticle()" type="button">기록 저장</button>
+                <button class="btn btn-primary" onclick="postArticle()" type="button">기록 저장</button>
+            </div>
         </div>
-    </div>
-    <div class="card-columns" id="cards-box">
-    </div>
-</div>
-
+        
     </div>
 
     <footer class="wrap">


### PR DESCRIPTION
index.html 와 write.html 에 `모바일 버전으로 볼 수 있는 css 추가`했습니다.
index.html는 레이아웃 정리를 더 해야하지만 ajax 설정(백틱 사용)을 하면 해결될 부분이라고 생각합니다.

또 index.html 와 write.html 에서 `href= [html 파일명] `로 된 것을 app.py를 보고 설정된` "/" 와 "/menu1"`로 바꿨습니다.
- app.py 를 run해서 사이트 열었을 때 html 파일명으로 된 것이 안 열렸기 때문

아래는 write.html 파일 예시
기존
```
<div class="topnav">
        <a href="index.html">우리의 여행일기</a>
        <a class="active" href="write.html">일기 쓰기</a>
        <a href="#mypost">내 일기 모아보기</a>
        <a href="#about">about</a>
    </div>
```
수정
```
<div class="topnav">
        <a href="/">우리의 여행일기</a>
        <a class="active" href="/menu1">일기 쓰기</a>
        <a href="#mypost">내 일기 모아보기</a>
        <a href="#about">about</a>
    </div>
```